### PR TITLE
DSL for more test steps

### DIFF
--- a/readyapi4j-core/src/main/java/com/smartbear/readyapi4j/teststeps/plugin/PluginTestStepBuilder.java
+++ b/readyapi4j-core/src/main/java/com/smartbear/readyapi4j/teststeps/plugin/PluginTestStepBuilder.java
@@ -3,6 +3,8 @@ package com.smartbear.readyapi4j.teststeps.plugin;
 import com.smartbear.readyapi.client.model.PluginTestStep;
 import com.smartbear.readyapi4j.teststeps.TestStepBuilder;
 
+import java.util.Map;
+
 public class PluginTestStepBuilder implements TestStepBuilder<PluginTestStep> {
     private final PluginTestStep pluginTestStep = new PluginTestStep();
 
@@ -12,6 +14,11 @@ public class PluginTestStepBuilder implements TestStepBuilder<PluginTestStep> {
 
     public PluginTestStepBuilder named(String testStepName) {
         pluginTestStep.setName(testStepName);
+        return this;
+    }
+
+    public PluginTestStepBuilder withConfigProperties(Map<String, Object> configuration) {
+        pluginTestStep.getConfiguration().putAll(configuration);
         return this;
     }
 

--- a/test-dsl/src/main/groovy/com/smartbear/readyapi4j/dsl/DeferredPropertyTransferBuilder.groovy
+++ b/test-dsl/src/main/groovy/com/smartbear/readyapi4j/dsl/DeferredPropertyTransferBuilder.groovy
@@ -18,6 +18,7 @@ class DeferredPropertyTransferBuilder {
     private TestRecipeBuilder recipeBuilder
     private Map targetOptions
     private PropertyTransferBuilder transfer
+    private String testStepName
 
     DeferredPropertyTransferBuilder(Map sourceProperties, TestRecipeBuilder recipeBuilder) {
         extractSourceProperties(sourceProperties)
@@ -40,6 +41,11 @@ class DeferredPropertyTransferBuilder {
         this([path: sourcePath], recipeBuilder)
     }
 
+    DeferredPropertyTransferBuilder name(String testStepName) {
+        this.testStepName = testStepName
+        return this
+    }
+
     DeferredPropertyTransferBuilder from(Map sourceOptions) {
         extractSourceProperties(sourceOptions)
         return this
@@ -57,7 +63,9 @@ class DeferredPropertyTransferBuilder {
                 .withPath(sourcePath)
         PropertyTransferTargetBuilder target = makeTarget(targetProperties)
         transfer = new PropertyTransferBuilder().withSource(source).withTarget(target)
-        recipeBuilder.addStep(new PropertyTransferTestStepBuilder().addTransfer(this.transfer))
+        PropertyTransferTestStepBuilder testStepBuilder = new PropertyTransferTestStepBuilder().addTransfer(this.transfer)
+        testStepBuilder.named(testStepName)
+        recipeBuilder.addStep(testStepBuilder)
         return this
     }
 

--- a/test-dsl/src/main/groovy/com/smartbear/readyapi4j/dsl/DslDelegate.groovy
+++ b/test-dsl/src/main/groovy/com/smartbear/readyapi4j/dsl/DslDelegate.groovy
@@ -7,6 +7,7 @@ import com.smartbear.readyapi4j.teststeps.TestSteps
 import com.smartbear.readyapi4j.teststeps.groovyscript.GroovyScriptTestStepBuilder
 import com.smartbear.readyapi4j.teststeps.jdbcrequest.JdbcRequestTestStepBuilder
 import com.smartbear.readyapi4j.teststeps.mockresponse.SoapMockResponseTestStepBuilder
+import com.smartbear.readyapi4j.teststeps.plugin.PluginTestStepBuilder
 import com.smartbear.readyapi4j.teststeps.properties.PropertiesTestStepBuilder
 import com.smartbear.readyapi4j.teststeps.propertytransfer.PropertyTransferBuilder
 import com.smartbear.readyapi4j.teststeps.propertytransfer.PropertyTransferTestStepBuilder
@@ -63,6 +64,18 @@ class DslDelegate {
         PropertiesTestStepBuilder propertiesTestStepBuilder = TestSteps.properties(properties)
         propertiesTestStepBuilder.named(testStepName)
         recipeBuilder.addStep(propertiesTestStepBuilder)
+    }
+
+    void pluginProvidedStep(@DelegatesTo(PluginTestStepDelegate) Closure pluginTestStepDefinition) {
+        PluginTestStepDelegate delegate = new PluginTestStepDelegate()
+        pluginTestStepDefinition.delegate = delegate
+        pluginTestStepDefinition.call()
+
+        PluginTestStepBuilder pluginTestStepBuilder = TestSteps.pluginTestStep(delegate.type)
+                .withConfigProperties(delegate.configuration)
+                .named(delegate.testStepName)
+
+        recipeBuilder.addStep(pluginTestStepBuilder)
     }
 
     static final Map request = Collections.unmodifiableMap([property: 'Request'])

--- a/test-dsl/src/main/groovy/com/smartbear/readyapi4j/dsl/DslDelegate.groovy
+++ b/test-dsl/src/main/groovy/com/smartbear/readyapi4j/dsl/DslDelegate.groovy
@@ -4,9 +4,12 @@ import com.smartbear.readyapi4j.TestRecipe
 import com.smartbear.readyapi4j.TestRecipeBuilder
 import com.smartbear.readyapi4j.execution.RecipeExecutionException
 import com.smartbear.readyapi4j.teststeps.TestSteps
+import com.smartbear.readyapi4j.teststeps.groovyscript.GroovyScriptTestStepBuilder
 import com.smartbear.readyapi4j.teststeps.jdbcrequest.JdbcRequestTestStepBuilder
 import com.smartbear.readyapi4j.teststeps.mockresponse.SoapMockResponseTestStepBuilder
+import com.smartbear.readyapi4j.teststeps.properties.PropertiesTestStepBuilder
 import com.smartbear.readyapi4j.teststeps.propertytransfer.PropertyTransferBuilder
+import com.smartbear.readyapi4j.teststeps.propertytransfer.PropertyTransferTestStepBuilder
 import com.smartbear.readyapi4j.teststeps.restrequest.RestRequestStepBuilder
 
 /**
@@ -16,8 +19,10 @@ class DslDelegate {
 
     private TestRecipeBuilder recipeBuilder = new TestRecipeBuilder()
 
-    void groovyScriptStep(String scriptText) {
-        recipeBuilder.addStep(TestSteps.groovyScriptStep(scriptText))
+    void groovyScriptStep(String scriptText, String testStepName = null) {
+        GroovyScriptTestStepBuilder scriptTestStepBuilder = TestSteps.groovyScriptStep(scriptText)
+        scriptTestStepBuilder.named(testStepName)
+        recipeBuilder.addStep(scriptTestStepBuilder)
     }
 
     void get(String URI, @DelegatesTo(RestRequestDelegate) Closure configuration = null) {
@@ -36,8 +41,10 @@ class DslDelegate {
         createRestRequest('DELETE', URI, configuration)
     }
 
-    void transfer(PropertyTransferBuilder transferBuilder) {
-        recipeBuilder.addStep(TestSteps.propertyTransfer(transferBuilder))
+    void transfer(PropertyTransferBuilder transferBuilder, String testStepName = null) {
+        PropertyTransferTestStepBuilder transferTestStepBuilder = TestSteps.propertyTransfer(transferBuilder)
+        transferTestStepBuilder.named(testStepName)
+        recipeBuilder.addStep(transferTestStepBuilder)
     }
 
     DeferredPropertyTransferBuilder transfer(String sourcePath) {
@@ -50,6 +57,12 @@ class DslDelegate {
 
     DeferredDelayStepBuilder pause(BigDecimal time) {
         return new DeferredDelayStepBuilder(time, recipeBuilder)
+    }
+
+    void properties(Map<String, String> properties = [:], String testStepName = null) {
+        PropertiesTestStepBuilder propertiesTestStepBuilder = TestSteps.properties(properties)
+        propertiesTestStepBuilder.named(testStepName)
+        recipeBuilder.addStep(propertiesTestStepBuilder)
     }
 
     static final Map request = Collections.unmodifiableMap([property: 'Request'])

--- a/test-dsl/src/main/groovy/com/smartbear/readyapi4j/dsl/PluginTestStepDelegate.groovy
+++ b/test-dsl/src/main/groovy/com/smartbear/readyapi4j/dsl/PluginTestStepDelegate.groovy
@@ -1,0 +1,22 @@
+package com.smartbear.readyapi4j.dsl
+
+/**
+ * Delegate to support 'pluginProvidedStep' closures within the DSL's recipe closures.
+ */
+class PluginTestStepDelegate {
+    String testStepName;
+    String type;
+    Map<String, Object> configuration;
+
+    void name(String testStepName) {
+        this.testStepName = testStepName
+    }
+
+    void type(String type) {
+        this.type = type
+    }
+
+    void configuration(Map<String, Object> configuration) {
+        this.configuration = configuration
+    }
+}

--- a/test-dsl/src/main/groovy/com/smartbear/readyapi4j/dsl/SoapMockResponseDelegate.groovy
+++ b/test-dsl/src/main/groovy/com/smartbear/readyapi4j/dsl/SoapMockResponseDelegate.groovy
@@ -1,0 +1,38 @@
+package com.smartbear.readyapi4j.dsl
+
+/**
+ * Delegate for the 'soapMockResponse'  closure in 'recipe' closure
+ */
+class SoapMockResponseDelegate {
+
+    String testStepName
+    String wsdlUrl
+    String binding
+    String operation
+    String path
+    int port
+
+    void setName(String testStepName) {
+        this.testStepName = testStepName
+    }
+
+    void setWsdl(String wsdlUrl) {
+        this.wsdlUrl = wsdlUrl
+    }
+
+    void setBinding(String binding) {
+        this.binding = binding
+    }
+
+    void setOperation(String operation) {
+        this.operation = operation
+    }
+
+    void setPath(String path) {
+        this.path = path
+    }
+
+    void setPort(int port) {
+        this.port = port
+    }
+}

--- a/test-dsl/src/test/groovy/com/smartbear/readyapi4j/dsl/PluginTestStepDslTest.groovy
+++ b/test-dsl/src/test/groovy/com/smartbear/readyapi4j/dsl/PluginTestStepDslTest.groovy
@@ -1,0 +1,31 @@
+package com.smartbear.readyapi4j.dsl
+
+import com.smartbear.readyapi.client.model.PluginTestStep
+import com.smartbear.readyapi4j.TestRecipe
+import org.junit.Test
+
+import static com.smartbear.readyapi4j.dsl.TestDsl.recipe
+
+
+class PluginTestStepDslTest {
+
+    private static final String TEST_STEP_TYPE = 'MQTTReceiveTestStep'
+    private static final String TEST_STEP_NAME = 'My plugin test step'
+
+    @Test
+    void createsRecipeWithPluginProvidedTestStep() throws Exception {
+        TestRecipe testRecipe = recipe {
+            pluginProvidedStep {
+                type TEST_STEP_TYPE
+                name TEST_STEP_NAME
+                configuration property1: 'value1', property2: [nestedProperty1: 'nestedValue1']
+            }
+        }
+        PluginTestStep pluginTestStep = testRecipe.testCase.testSteps[0] as PluginTestStep
+        assert pluginTestStep.type == TEST_STEP_TYPE
+        assert pluginTestStep.name == TEST_STEP_NAME
+        assert pluginTestStep.configuration['property1'] == 'value1'
+        assert pluginTestStep.configuration['property2'] == [nestedProperty1: 'nestedValue1']
+
+    }
+}

--- a/test-dsl/src/test/groovy/com/smartbear/readyapi4j/dsl/PropertiesTestStepDslTest.groovy
+++ b/test-dsl/src/test/groovy/com/smartbear/readyapi4j/dsl/PropertiesTestStepDslTest.groovy
@@ -1,0 +1,24 @@
+package com.smartbear.readyapi4j.dsl
+
+import com.smartbear.readyapi.client.model.PropertiesTestStep
+import com.smartbear.readyapi4j.TestRecipe
+import org.junit.Test
+
+import static com.smartbear.readyapi4j.dsl.TestDsl.recipe
+
+
+class PropertiesTestStepDslTest {
+
+    private static final Map<String, String> PROPERTIES_MAP = [property1: 'value1', property2: 'value2']
+    private static final String TEST_STEP_NAME = 'PropertiesTestStep'
+
+    @Test
+    void buildRecipeWithPropertiesTestStep() throws Exception {
+        TestRecipe testRecipe = recipe {
+            properties PROPERTIES_MAP, TEST_STEP_NAME
+        }
+        PropertiesTestStep propertiesTestStep = testRecipe.testCase.testSteps[0] as PropertiesTestStep
+        assert propertiesTestStep.name == TEST_STEP_NAME
+        assert propertiesTestStep.properties == PROPERTIES_MAP
+    }
+}

--- a/test-dsl/src/test/groovy/com/smartbear/readyapi4j/dsl/ScriptTestStepDslTest.groovy
+++ b/test-dsl/src/test/groovy/com/smartbear/readyapi4j/dsl/ScriptTestStepDslTest.groovy
@@ -10,6 +10,7 @@ import static com.smartbear.readyapi4j.dsl.DataExtractor.extractFirstTestStep
 class ScriptTestStepDslTest {
 
     private static final String SCRIPT_TEXT = "println 'Peekaboo, little Earth'"
+    private static final String TEST_STEP_NAME = 'GroovyTestStep'
 
     @Test
     void buildsSimpleRecipe() throws Exception {
@@ -18,6 +19,17 @@ class ScriptTestStepDslTest {
         }
 
         GroovyScriptTestStep singleStep = extractFirstTestStep(recipe) as GroovyScriptTestStep
+        assert singleStep.script == SCRIPT_TEXT
+    }
+
+    @Test
+    void buildsGroovyStepWithName() throws Exception {
+        TestRecipe recipe = recipe {
+            groovyScriptStep SCRIPT_TEXT, TEST_STEP_NAME
+        }
+
+        GroovyScriptTestStep singleStep = extractFirstTestStep(recipe) as GroovyScriptTestStep
+        assert singleStep.name == TEST_STEP_NAME
         assert singleStep.script == SCRIPT_TEXT
     }
 

--- a/test-dsl/src/test/groovy/com/smartbear/readyapi4j/dsl/SoapMockResponseDslTest.groovy
+++ b/test-dsl/src/test/groovy/com/smartbear/readyapi4j/dsl/SoapMockResponseDslTest.groovy
@@ -1,0 +1,38 @@
+package com.smartbear.readyapi4j.dsl
+
+import com.smartbear.readyapi.client.model.SoapMockResponseTestStep
+import com.smartbear.readyapi4j.TestRecipe
+import org.junit.Test
+
+import static com.smartbear.readyapi4j.dsl.TestDsl.recipe
+
+class SoapMockResponseDslTest {
+    private static final String WSDL_URL = 'http://somedomain.com/service?wsdl'
+    private static final String BINDING = 'TheBinding'
+    private static final String OPERATION = 'TheOperation'
+    private static final String PATH = '/mymockservice'
+    private static final int PORT = 8080
+    private static final String TEST_STEP_NAME = 'SOAP Mock Response'
+
+    @Test
+    void buildsSoapMockResponseTestStep() throws Exception {
+        TestRecipe recipe = recipe {
+            soapMockResponse {
+                name = TEST_STEP_NAME
+                wsdl = WSDL_URL
+                binding = BINDING
+                operation = OPERATION
+                path = PATH
+                port = PORT
+            }
+        }
+
+        SoapMockResponseTestStep testStep = recipe.testCase.testSteps[0] as SoapMockResponseTestStep
+        assert testStep.name == TEST_STEP_NAME
+        assert testStep.wsdl == WSDL_URL
+        assert testStep.binding == BINDING
+        assert testStep.operation == OPERATION
+        assert testStep.path == PATH
+        assert testStep.port == PORT
+    }
+}


### PR DESCRIPTION
Adds DSL for:
1. SOAP Mock response test step
2. Properties test step
3. Plugin provided test step

With this PR we have DSL fro all the test steps available in readyapi4j for SoapUI OS.

Also, introduced optional parameter to set test step name, for the step where it was missing.

