### PR TITLE
Recipe execution with dsl

### DIFF
--- a/readyapi4j-groovy-dsl/src/main/groovy/com/smartbear/readyapi4j/dsl/SoapMockResponseDelegate.groovy
+++ b/readyapi4j-groovy-dsl/src/main/groovy/com/smartbear/readyapi4j/dsl/SoapMockResponseDelegate.groovy
@@ -1,38 +1,43 @@
 package com.smartbear.readyapi4j.dsl
 
+import com.smartbear.readyapi4j.execution.RecipeExecutionException
+import com.smartbear.readyapi4j.teststeps.mockresponse.SoapMockResponseTestStepBuilder
+
 /**
  * Delegate for the 'soapMockResponse'  closure in 'recipe' closure
  */
 class SoapMockResponseDelegate {
+    private SoapMockResponseTestStepBuilder soapMockResponseTestStepBuilder
 
-    String testStepName
-    String wsdlUrl
-    String binding
-    String operation
-    String path
-    int port
+    SoapMockResponseDelegate(SoapMockResponseTestStepBuilder soapMockResponseTestStepBuilder) {
+        this.soapMockResponseTestStepBuilder = soapMockResponseTestStepBuilder
+    }
 
     void setName(String testStepName) {
-        this.testStepName = testStepName
+        soapMockResponseTestStepBuilder.named(testStepName)
     }
 
     void setWsdl(String wsdlUrl) {
-        this.wsdlUrl = wsdlUrl
+        try {
+            soapMockResponseTestStepBuilder.withWsdlAt(new URL(wsdlUrl))
+        } catch (MalformedURLException e) {
+            throw new RecipeExecutionException("Not a valid WSDL location: $wsdlUrl", e)
+        }
     }
 
     void setBinding(String binding) {
-        this.binding = binding
+        soapMockResponseTestStepBuilder.forBinding(binding)
     }
 
     void setOperation(String operation) {
-        this.operation = operation
+        soapMockResponseTestStepBuilder.forOperation(operation)
     }
 
     void setPath(String path) {
-        this.path = path
+        soapMockResponseTestStepBuilder.withPath(path)
     }
 
     void setPort(int port) {
-        this.port = port
+        soapMockResponseTestStepBuilder.withPort(port)
     }
 }

--- a/readyapi4j-groovy-dsl/src/main/groovy/com/smartbear/readyapi4j/dsl/SoapRequestDelegate.groovy
+++ b/readyapi4j-groovy-dsl/src/main/groovy/com/smartbear/readyapi4j/dsl/SoapRequestDelegate.groovy
@@ -1,6 +1,5 @@
 package com.smartbear.readyapi4j.dsl
 
-import com.smartbear.readyapi4j.assertions.AssertionBuilder
 import com.smartbear.readyapi4j.dsl.assertions.SoapRequestAssertionsDelegate
 import com.smartbear.readyapi4j.execution.RecipeExecutionException
 import com.smartbear.readyapi4j.teststeps.soaprequest.SoapRequestStepBuilder
@@ -10,31 +9,34 @@ import com.smartbear.readyapi4j.teststeps.soaprequest.SoapRequestStepBuilder
  */
 class SoapRequestDelegate {
 
-    private String wsdlString
-    private String binding
-    private String operation
-    private Map<String, String> pathParameters = [:]
-    private Map<String, String> namedParameters = [:]
-    private List<AssertionBuilder> assertions
+    private SoapRequestStepBuilder soapRequestStepBuilder
+
+    SoapRequestDelegate(SoapRequestStepBuilder soapRequestStepBuilder) {
+        this.soapRequestStepBuilder = soapRequestStepBuilder
+    }
 
     void setWsdl(String wsdlUrl) {
-        this.wsdlString = wsdlUrl
+        try {
+            soapRequestStepBuilder.withWsdlAt(new URL(wsdlUrl))
+        } catch (MalformedURLException e) {
+            throw new RecipeExecutionException("Not a valid WSDL location: $wsdlUrl", e)
+        }
     }
 
     void setBinding(String binding) {
-        this.binding = binding
+        soapRequestStepBuilder.forBinding(binding)
     }
 
     void setOperation(String operation) {
-        this.operation = operation
+        soapRequestStepBuilder.forOperation(operation)
     }
 
     void pathParam(String path, Object value) {
-        pathParameters[path] = value as String
+        soapRequestStepBuilder.withPathParameter(path, value as String)
     }
 
     void namedParam(String name, Object value) {
-        namedParameters[name] = value as String
+        soapRequestStepBuilder.withParameter(name, value as String)
     }
 
     void asserting(@DelegatesTo(SoapRequestAssertionsDelegate) Closure assertionsConfig) {
@@ -44,26 +46,6 @@ class SoapRequestDelegate {
         // name being converted into URI, e.g. "soapFault
         assertionsConfig.resolveStrategy = Closure.DELEGATE_FIRST
         assertionsConfig.call()
-        this.assertions = delegate.assertionBuilders
-    }
-
-    SoapRequestStepBuilder buildSoapRequestStep() {
-        SoapRequestStepBuilder builder = new SoapRequestStepBuilder()
-                .forBinding(binding)
-                .forOperation(operation)
-        try {
-            builder.withWsdlAt(new URL(wsdlString))
-        } catch (MalformedURLException e) {
-            throw new RecipeExecutionException("Not a valid WSDL location: $wsdlString", e)
-        }
-
-        pathParameters.each { path, value ->
-            builder.withPathParameter(path, value)
-        }
-        namedParameters.each { name, value ->
-            builder.withParameter(name, value)
-        }
-        assertions.each { assertion -> builder.addAssertion(assertion) }
-        return builder
+        delegate.assertionBuilders.each { assertion -> soapRequestStepBuilder.addAssertion(assertion) }
     }
 }

--- a/readyapi4j-groovy-dsl/src/main/groovy/com/smartbear/readyapi4j/dsl/execution/RecipeExecution.groovy
+++ b/readyapi4j-groovy-dsl/src/main/groovy/com/smartbear/readyapi4j/dsl/execution/RecipeExecution.groovy
@@ -67,10 +67,11 @@ class RecipeExecution {
     }
 
     /**
-     * Asynchronous execution: submits recipe for execution and returns current state of execution.
+     * Executes recipe locally and returns execution results.
+     * It requires dependency on com.smartbear.readyapi:readyapi4j-local or the corresponding jars in classpath.
      * @param executor
      * @param recipeDefinition
-     * @return Execution : with current state of execution
+     * @return Execution : execution result
      */
     static Execution executeRecipeLocally(@DelegatesTo(ProDslDelegate) recipeDefinition) {
         TestRecipe testRecipe = createTestRecipe(recipeDefinition)

--- a/readyapi4j-groovy-dsl/src/main/groovy/com/smartbear/readyapi4j/dsl/execution/RecipeExecution.groovy
+++ b/readyapi4j-groovy-dsl/src/main/groovy/com/smartbear/readyapi4j/dsl/execution/RecipeExecution.groovy
@@ -73,7 +73,7 @@ class RecipeExecution {
      * @param recipeDefinition
      * @return Execution : execution result
      */
-    static Execution executeRecipeLocally(@DelegatesTo(ProDslDelegate) recipeDefinition) {
+    static Execution executeRecipe(@DelegatesTo(ProDslDelegate) recipeDefinition) {
         TestRecipe testRecipe = createTestRecipe(recipeDefinition)
         Class soapUIRecipeExecutorClass
         try {

--- a/readyapi4j-groovy-dsl/src/main/groovy/com/smartbear/readyapi4j/dsl/execution/RecipeExecution.groovy
+++ b/readyapi4j-groovy-dsl/src/main/groovy/com/smartbear/readyapi4j/dsl/execution/RecipeExecution.groovy
@@ -1,0 +1,95 @@
+package com.smartbear.readyapi4j.dsl.execution
+
+import com.smartbear.readyapi4j.TestRecipe
+import com.smartbear.readyapi4j.TestRecipeBuilder
+import com.smartbear.readyapi4j.dsl.pro.ProDslDelegate
+import com.smartbear.readyapi4j.execution.Execution
+import com.smartbear.readyapi4j.execution.RecipeExecutor
+import com.smartbear.readyapi4j.testserver.execution.TestServerClient
+
+class RecipeExecution {
+
+    /**
+     * Creates an instance of TestServerClient for remote execution of recipes.
+     * @param testServerUrl https://<server hostname or ip> : <port>
+     * @param username username
+     * @param password password
+     * @return TestServerClient
+     */
+    static RecipeExecutor remoteRecipeExecutor(String testServerUrl, String username, String password) {
+        TestServerClient testServerClient = TestServerClient.fromUrl(testServerUrl)
+        testServerClient.setCredentials(username, password)
+        testServerClient.createRecipeExecutor()
+    }
+
+    /**
+     * Executes recipe and returns execution results
+     * @param executor
+     * @param recipeDefinition
+     * @return Execution : containing the execution result
+     */
+    static Execution executeRecipe(RecipeExecutor executor, @DelegatesTo(ProDslDelegate) recipeDefinition) {
+        TestRecipe testRecipe = createTestRecipe(recipeDefinition)
+        return executor.executeRecipe(testRecipe)
+    }
+
+    /**
+     * Executes recipe on TestServer and returns execution results
+     * @param executor
+     * @param recipeDefinition
+     * @return Execution : containing the execution result
+     */
+    static Execution executeRecipeOnServer(String testServerUrl, String username, String password,
+                                           @DelegatesTo(ProDslDelegate) recipeDefinition) {
+        return executeRecipe(remoteRecipeExecutor(testServerUrl, username, password), recipeDefinition)
+    }
+
+    /**
+     * Asynchronous execution: submits recipe for execution and returns current state of execution.
+     * @param executor
+     * @param recipeDefinition
+     * @return Execution : with current state of execution
+     */
+    static Execution submitRecipe(RecipeExecutor executor, @DelegatesTo(ProDslDelegate) recipeDefinition) {
+        TestRecipe testRecipe = createTestRecipe(recipeDefinition)
+        return executor.submitRecipe(testRecipe)
+    }
+
+    /**
+     * Submits recipe to TestServer for asynchronous execution and returns current state of execution
+     * @param executor
+     * @param recipeDefinition
+     * @return Execution : containing the execution result
+     */
+    static Execution submitRecipeToServer(String testServerUrl, String username, String password,
+                                          @DelegatesTo(ProDslDelegate) recipeDefinition) {
+        return submitRecipe(remoteRecipeExecutor(testServerUrl, username, password), recipeDefinition)
+    }
+
+    /**
+     * Asynchronous execution: submits recipe for execution and returns current state of execution.
+     * @param executor
+     * @param recipeDefinition
+     * @return Execution : with current state of execution
+     */
+    static Execution executeRecipeLocally(@DelegatesTo(ProDslDelegate) recipeDefinition) {
+        TestRecipe testRecipe = createTestRecipe(recipeDefinition)
+        Class soapUIRecipeExecutorClass
+        try {
+            soapUIRecipeExecutorClass = Class.forName("com.smartbear.readyapi4j.local.execution.SoapUIRecipeExecutor")
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException('Could not instantiate local recipe executor.' +
+                    ' Please add dependency to com.smartbear.readyapi:readyapi4j-local or add the jars to classpath.')
+        }
+        def soapUIRecipeExecutor = soapUIRecipeExecutorClass.newInstance()
+        return soapUIRecipeExecutor.executeRecipe(testRecipe)
+    }
+
+    private static TestRecipe createTestRecipe(recipeDefinition) {
+        TestRecipeBuilder testRecipeBuilder = TestRecipeBuilder.newTestRecipe()
+        ProDslDelegate delegate = new ProDslDelegate(testRecipeBuilder)
+        recipeDefinition.delegate = delegate
+        recipeDefinition.call()
+        return testRecipeBuilder.buildTestRecipe()
+    }
+}

--- a/readyapi4j-groovy-dsl/src/main/groovy/com/smartbear/readyapi4j/dsl/execution/RecipeExecution.groovy
+++ b/readyapi4j-groovy-dsl/src/main/groovy/com/smartbear/readyapi4j/dsl/execution/RecipeExecution.groovy
@@ -10,7 +10,7 @@ import com.smartbear.readyapi4j.testserver.execution.TestServerClient
 class RecipeExecution {
 
     /**
-     * Creates an instance of TestServerClient for remote execution of recipes.
+     * Creates an instance of TestServerClient for remote execution of recipes. Can be used in set-up methods in tests.
      * @param testServerUrl https://<server hostname or ip> : <port>
      * @param username username
      * @param password password

--- a/readyapi4j-groovy-dsl/src/test/groovy/com/smartbear/readyapi4j/dsl/execution/RecipeExecutionTest.groovy
+++ b/readyapi4j-groovy-dsl/src/test/groovy/com/smartbear/readyapi4j/dsl/execution/RecipeExecutionTest.groovy
@@ -4,14 +4,13 @@ import com.smartbear.readyapi4j.execution.Execution
 import com.smartbear.readyapi4j.execution.RecipeExecutor
 
 import static com.smartbear.readyapi4j.dsl.execution.RecipeExecution.executeRecipe
-import static com.smartbear.readyapi4j.dsl.execution.RecipeExecution.executeRecipeLocally
 
 class RecipeExecutionTest extends GroovyTestCase {
 
     void testThrowsExceptionWhenLocalRecipeExecutorNotInClasspath() throws Exception {
         shouldFail(IllegalStateException.class, {
-            executeRecipeLocally {
-                get 'http://google.com'
+            executeRecipe {
+                groovyScriptStep 'println Hello! From Groovy Script step.'
             }
         })
     }
@@ -19,7 +18,7 @@ class RecipeExecutionTest extends GroovyTestCase {
     void testRecipeExecutionWithRecipeExecutor() {
         RecipeExecutor recipeExecutor = new RecipeExecutorAdaptor()
         Execution execution = executeRecipe recipeExecutor, {
-            get 'http://google.com'
+            groovyScriptStep 'println Hello! From Groovy Script step.'
         }
         assert execution
     }

--- a/readyapi4j-groovy-dsl/src/test/groovy/com/smartbear/readyapi4j/dsl/execution/RecipeExecutionTest.groovy
+++ b/readyapi4j-groovy-dsl/src/test/groovy/com/smartbear/readyapi4j/dsl/execution/RecipeExecutionTest.groovy
@@ -1,0 +1,26 @@
+package com.smartbear.readyapi4j.dsl.execution
+
+import com.smartbear.readyapi4j.execution.Execution
+import com.smartbear.readyapi4j.execution.RecipeExecutor
+
+import static com.smartbear.readyapi4j.dsl.execution.RecipeExecution.executeRecipe
+import static com.smartbear.readyapi4j.dsl.execution.RecipeExecution.executeRecipeLocally
+
+class RecipeExecutionTest extends GroovyTestCase {
+
+    void testThrowsExceptionWhenLocalRecipeExecutorNotInClasspath() throws Exception {
+        shouldFail(IllegalStateException.class, {
+            executeRecipeLocally {
+                get 'http://google.com'
+            }
+        })
+    }
+
+    void testRecipeExecutionWithRecipeExecutor() {
+        RecipeExecutor recipeExecutor = new RecipeExecutorAdaptor()
+        Execution execution = executeRecipe recipeExecutor, {
+            get 'http://google.com'
+        }
+        assert execution
+    }
+}

--- a/readyapi4j-groovy-dsl/src/test/groovy/com/smartbear/readyapi4j/dsl/execution/RecipeExecutorAdaptor.groovy
+++ b/readyapi4j-groovy-dsl/src/test/groovy/com/smartbear/readyapi4j/dsl/execution/RecipeExecutorAdaptor.groovy
@@ -1,0 +1,47 @@
+package com.smartbear.readyapi4j.dsl.execution
+
+import com.smartbear.readyapi.client.model.ProjectResultReport
+import com.smartbear.readyapi4j.ExecutionListener
+import com.smartbear.readyapi4j.TestRecipe
+import com.smartbear.readyapi4j.execution.Execution
+import com.smartbear.readyapi4j.execution.RecipeExecutor
+import com.smartbear.readyapi4j.execution.RecipeFilter
+import com.smartbear.readyapi4j.testserver.execution.TestServerExecution
+
+
+class RecipeExecutorAdaptor implements RecipeExecutor {
+    @Override
+    Execution submitRecipe(TestRecipe recipe) {
+        return new TestServerExecution(null, null, new ProjectResultReport())
+    }
+
+    @Override
+    Execution executeRecipe(TestRecipe recipe) {
+        return new TestServerExecution(null, null, new ProjectResultReport())
+    }
+
+    @Override
+    List<Execution> getExecutions() {
+        return null
+    }
+
+    @Override
+    void addExecutionListener(ExecutionListener listener) {
+
+    }
+
+    @Override
+    void removeExecutionListener(ExecutionListener listener) {
+
+    }
+
+    @Override
+    void addRecipeFilter(RecipeFilter recipeFilter) {
+
+    }
+
+    @Override
+    void removeRecipeFilter(RecipeFilter recipeFilter) {
+
+    }
+}


### PR DESCRIPTION
Added a class RecipeExecution which can be used in DSL. It can be provided with a Recipe as a closure for local or remote execution.
Alos, refactored the DSL code a bit to hide unnecessary details from end user.