### PR TITLE
Adding readyapi4j-maven-plugin

### DIFF
--- a/modules/maven-plugin-tester/pom.xml
+++ b/modules/maven-plugin-tester/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>readyapi4j</artifactId>
+        <groupId>com.smartbear.readyapi</groupId>
+        <version>2.0.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>readyapi4j-maven-plugin-tester</artifactId>
+    <dependencies>
+        <dependency>
+            <groupId>com.smartbear.readyapi</groupId>
+            <artifactId>readyapi4j-maven-plugin</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.smartbear.readyapi</groupId>
+                <artifactId>readyapi4j-maven-plugin</artifactId>
+                <version>${project.version}</version>
+                <configuration>
+                    <username>demoUser</username>
+                    <password>demoPassword</password>
+                    <server>http://testserver.readyapi.io:8080</server>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>run</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/modules/maven-plugin-tester/src/test/resources/recipes/soapui-project.xml
+++ b/modules/maven-plugin-tester/src/test/resources/recipes/soapui-project.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<con:soapui-project id="f18ae7a5-8493-4e65-80bc-11e30104fb25" activeEnvironment="Default environment" name="REST Project 3" lastOpened="2017-03-08T17:10:55.764+01:00" resourceRoot="" soapui-version="6.0.0" xmlns:con="http://eviware.com/soapui/config">
+  <con:settings/>
+  <con:interface xsi:type="con:RestService" id="b6de7829-63da-45e1-bcb9-7e11940d1762" wadlVersion="http://wadl.dev.java.net/2009/02" name="https://api.swaggerhub.com" type="rest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <con:settings/>
+    <con:definitionCache type="TEXT" rootPart=""/>
+    <con:endpoints>
+      <con:endpoint>https://api.swaggerhub.com</con:endpoint>
+    </con:endpoints>
+    <con:resource name="Apis" path="/apis" id="285d67f2-14ce-4738-9e71-3e46c2244d0a">
+      <con:settings/>
+      <con:parameters>
+        <con:parameter>
+          <con:name>query</con:name>
+          <con:value>testserver</con:value>
+          <con:style>QUERY</con:style>
+          <con:default>testserver</con:default>
+          <con:path xsi:nil="true"/>
+          <con:description xsi:nil="true"/>
+        </con:parameter>
+      </con:parameters>
+      <con:method name="Apis" id="f5f7af10-8be4-4ca6-a1a7-91734010fa49" method="GET">
+        <con:settings/>
+        <con:parameters/>
+        <con:representation type="RESPONSE">
+          <con:mediaType>application/json</con:mediaType>
+          <con:status>200</con:status>
+          <con:params/>
+          <con:element xmlns:apis="https://api.swaggerhub.com/apis">apis:Response</con:element>
+        </con:representation>
+        <con:request name="Request 1" id="a0ba25e4-c170-4fb6-971a-e671437c6263" mediaType="application/json">
+          <con:settings/>
+          <con:endpoint>https://api.swaggerhub.com</con:endpoint>
+          <con:request/>
+          <con:credentials>
+            <con:authType>No Authorization</con:authType>
+          </con:credentials>
+          <con:jmsConfig JMSDeliveryMode="PERSISTENT"/>
+          <con:parameters>
+            <entry key="query" value="testserver" xmlns="http://eviware.com/soapui/config"/>
+          </con:parameters>
+          <con:parameterOrder>
+            <con:entry>query</con:entry>
+          </con:parameterOrder>
+        </con:request>
+      </con:method>
+    </con:resource>
+  </con:interface>
+  <con:testSuite id="2570b904-5b7b-4f1f-b691-819156b5f9c8" name="https://api.swaggerhub.com TestSuite">
+    <con:settings/>
+    <con:runType>SEQUENTIAL</con:runType>
+    <con:testCase id="b7a83963-9cbb-4804-9a2b-f7c1f781bca8" discardOkResults="true" failOnError="true" failTestCaseOnErrors="true" keepSession="false" name="https://api.swaggerhub.com TestCase" searchProperties="true" timeout="0">
+      <con:settings/>
+      <con:savedRecentRuns>1</con:savedRecentRuns>
+      <con:testStep type="restrequest" name="Request 1" id="c5ebc04f-b83f-4e14-ae39-9c6eaa02a205">
+        <con:settings/>
+        <con:config service="https://api.swaggerhub.com" resourcePath="/apis" methodName="Apis" xsi:type="con:RestRequestStep" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+          <con:restRequest name="Request 1" id="a0ba25e4-c170-4fb6-971a-e671437c6263" mediaType="application/json">
+            <con:settings>
+              <con:setting id="com.eviware.soapui.impl.wsdl.WsdlRequest@request-headers">&lt;xml-fragment/></con:setting>
+            </con:settings>
+            <con:endpoint>https://api.swaggerhub.com</con:endpoint>
+            <con:request/>
+            <con:originalUri>https://api.swaggerhub.com/apis</con:originalUri>
+            <con:assertion type="Valid HTTP Status Codes" id="19b852ab-473d-472a-a60a-680f34a6e345" name="Valid HTTP Status Codes">
+              <con:settings/>
+              <con:configuration>
+                <codes>200</codes>
+              </con:configuration>
+            </con:assertion>
+            <con:assertion type="JsonPath Count" id="1feabf45-99a6-4f47-aeb3-4eb3433e9f2f" name="JsonPath Count">
+              <con:configuration>
+                <path>$.totalCount</path>
+                <content>1</content>
+                <allowWildcards>false</allowWildcards>
+                <ignoreNamspaceDifferences>false</ignoreNamspaceDifferences>
+                <ignoreComments>false</ignoreComments>
+              </con:configuration>
+            </con:assertion>
+            <con:credentials>
+              <con:selectedAuthProfile>No Authorization</con:selectedAuthProfile>
+              <con:authType>No Authorization</con:authType>
+            </con:credentials>
+            <con:jmsConfig JMSDeliveryMode="PERSISTENT"/>
+            <con:parameters>
+              <entry key="query" value="testserver" xmlns="http://eviware.com/soapui/config"/>
+            </con:parameters>
+            <con:parameterOrder>
+              <con:entry>query</con:entry>
+            </con:parameterOrder>
+          </con:restRequest>
+        </con:config>
+      </con:testStep>
+      <con:properties/>
+      <con:reportParameters/>
+    </con:testCase>
+    <con:properties/>
+    <con:reportParameters/>
+  </con:testSuite>
+  <con:requirements/>
+  <con:properties/>
+  <con:wssContainer/>
+  <con:databaseConnectionContainer/>
+  <con:oAuth2ProfileContainer/>
+  <con:reporting>
+    <con:xmlTemplates/>
+    <con:parameters/>
+  </con:reporting>
+  <con:authRepository/>
+  <con:tags/>
+</con:soapui-project>

--- a/modules/maven-plugin-tester/src/test/resources/recipes/test-recipe.json
+++ b/modules/maven-plugin-tester/src/test/resources/recipes/test-recipe.json
@@ -1,0 +1,30 @@
+{
+  "testSteps": [
+    {
+      "type": "REST Request",
+      "method": "GET",
+      "URI": "https://api.swaggerhub.com/apis",
+      "parameters": [
+        {
+          "type": "QUERY",
+          "name": "query",
+          "value": "testserver"
+        }
+      ],
+      "assertions": [
+        {
+          "type": "Valid HTTP Status Codes",
+          "validStatusCodes": [
+            "200"
+          ]
+        },
+        {
+          "type": "JsonPath Count",
+          "jsonPath": "$.totalCount",
+          "expectedCount": "1",
+          "allowWildcards": false
+        }
+      ]
+    }
+  ]
+}

--- a/modules/maven-plugin/README.md
+++ b/modules/maven-plugin/README.md
@@ -1,0 +1,120 @@
+# ReadyApi4J TestServer Maven Plugin
+
+A maven plugin that runs a set of Json recipes (locally or using a TestServer) and Ready! API projects (only with TestServer, not locally) - 
+configure it to run in whatever build phase you might find relevant, for example;
+
+```
+<plugin>
+    <groupId>com.smartbear.readyapi</groupId>
+    <artifactId>readyapi4j-maven-plugin</artifactId>
+    <version>2.0.0-SNAPSHOT</version>
+    <configuration>
+        <username>defaultUser</username>
+        <password>defaultPassword</password>
+        <server>...Ready!API TestServer endpoint...</server>
+    </configuration>
+    <executions>
+        <execution>
+            <id>run</id>
+            <phase>integration-test</phase>
+            <goals>
+                <goal>run</goal>
+            </goals>
+        </execution>
+    </executions>
+</plugin>
+```
+
+The only goal exposed by the plugin is "run" - you can invoke it as above or directly from the command-line, for example
+
+```
+mvn testserver:run 
+```
+
+The plugin will look for files with either json or xml extensions.
+
+## Configuration
+
+Configuration parameters are:
+
+* username (required) : the TestServer username to use for authentication
+* password (required) : the TestServer password to use for authentication
+* server (required) : endpoint of the TestServer (no trailing slash!)
+* recipeDirectory : the folder to scan recursively for recipes/projects, defaults to ${project.basedir}/src/test/resources/recipes
+* targetDirectory : the folder to which filtered recipes will be copied before executing, defaults
+to ${project.basedir}/target/test-recipes
+* properties : an optional set of additional properties that will be used during filtering (see below)
+* disableFiltering : disables filtering of recipes - if set to true the recipes will not be copied and filtere
+to the target directory, instead they will run directly from the source directory.
+* reportTarget : the folder to which a junit-report.xml file will be generated (as can be processed by 
+the surefire plugin), defaults to ${basedir}/target/surefire-reports
+* environment : if you're submitting existing SoapUI/Ready!API project files this allows you to select which environment 
+to target
+* async : toggle if tests should be executed asynchronously - default is false which will wait for tests to finish 
+ to be able to create test-reports. Setting this to true will disable reporting functionality, but allow you 
+to specify an optional callback that will be called by the TestServer with test results when they are finished.
+* callback : an optional url to call with finished test results if async is set to true 
+
+Specifying a skipApiTests system property will bypass this plugin altogether.
+
+The plugin will also look for standard properties file named recipe.properties in the recipeDirectory folder and
+load any properties in this file before applying the properties specified in the configuration.
+
+## Filtering
+
+Json recipes will be filtered and copied to the folder specified by targetDirectory before getting executed. 
+Any available property will be replaced, which makes it easy to parameterize your tests.
+
+For example the following simple recipe:
+
+```
+{
+    "testSteps": [
+        {
+            "type": "REST Request",
+            "method": "GET",
+            "URI": "${apitest.host}/apis",
+            "assertions": [
+                {
+                    "type": "Valid HTTP Status Codes",
+                    "validStatusCodes": [200]
+                }
+            ]
+        }
+    ]
+}
+```
+
+would use a property defined as 
+
+```
+...
+<apitest.host>...</apitest.host>
+...
+```              
+
+when assembling the URI. You can simply look in the targetDirectory folder after your tests were run to see what was 
+actually executed.
+
+## Error reporting
+
+Currently the plugin simple fails the build if any tests fail and dumps the Ready!API TestServer 
+response to the console. A surefire xml file is generated for inclusion in generated reports.
+
+## Building the plugin
+
+Simply pull this repo and run 
+
+```
+mvn clean install
+```
+
+to install the latest version of the plugin locally. It will eventually be made available on maven central also.
+
+
+## Next steps?
+
+Obviously huge list of things to improve:
+- support datadriven tests
+- improved surefire reports
+- etc..

--- a/modules/maven-plugin/pom.xml
+++ b/modules/maven-plugin/pom.xml
@@ -1,0 +1,103 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>readyapi4j</artifactId>
+        <groupId>com.smartbear.readyapi</groupId>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>readyapi4j-maven-plugin</artifactId>
+
+    <packaging>maven-plugin</packaging>
+    <name>ReadyAapi4J Maven Plugin</name>
+
+    <description>Maven plugin for executing test recipes locally or against Ready!API TestServer</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <version>3.4</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.smartbear.readyapi</groupId>
+            <artifactId>readyapi4j-facade</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>18.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-filtering</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>file-management</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.xmlbeans</groupId>
+            <artifactId>xmlbeans</artifactId>
+            <version>2.4.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.xmlbeans</groupId>
+            <artifactId>xmlbeans-xmlpublic</artifactId>
+            <version>2.4.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-plugin-plugin</artifactId>
+                <version>3.4</version>
+                <executions>
+                    <execution>
+                        <id>default-descriptor</id>
+                        <phase>process-classes</phase>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>xmlbeans-maven-plugin</artifactId>
+                <version>2.3.3</version>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>xmlbeans</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <inherited>true</inherited>
+                <configuration>
+                    <javaSource>1.5</javaSource>
+                    <verbose>false</verbose>
+                    <schemaDirectory>src/main/resources</schemaDirectory>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/modules/maven-plugin/src/main/java/com/smartbear/readyapi4j/maven/JUnitReport.java
+++ b/modules/maven-plugin/src/main/java/com/smartbear/readyapi4j/maven/JUnitReport.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2004-2015 SmartBear Software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.smartbear.readyapi4j.maven;
+
+import com.smartbear.readyapi.junit.ErrorDocument;
+import com.smartbear.readyapi.junit.FailureDocument;
+import com.smartbear.readyapi.junit.Properties;
+import com.smartbear.readyapi.junit.Property;
+import com.smartbear.readyapi.junit.Testcase;
+import com.smartbear.readyapi.junit.Testsuite;
+import com.smartbear.readyapi.junit.TestsuiteDocument;
+import org.apache.xmlbeans.XmlOptions;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Wrapper for a number of Test runs
+ */
+
+public class JUnitReport {
+    TestsuiteDocument testsuiteDoc;
+    int noofTestCases, noofFailures, noofErrors;
+    double totalTime;
+    StringBuffer systemOut;
+    StringBuffer systemErr;
+
+    boolean includeTestProperties;
+
+    public JUnitReport() {
+        systemOut = new StringBuffer();
+        systemErr = new StringBuffer();
+
+        testsuiteDoc = TestsuiteDocument.Factory.newInstance();
+        Testsuite testsuite = testsuiteDoc.addNewTestsuite();
+        Properties properties = testsuite.addNewProperties();
+        setSystemProperties(properties);
+    }
+
+    public void setIncludeTestProperties(boolean includeTestProperties) {
+        this.includeTestProperties = includeTestProperties;
+    }
+
+    public void setTotalTime(double time) {
+        testsuiteDoc.getTestsuite().setTime(Double.toString(Math.round(time * 1000) / 1000));
+    }
+
+    public void setTestSuiteName(String name) {
+        testsuiteDoc.getTestsuite().setName(name);
+    }
+
+    public void setPackage(String pkg) {
+        testsuiteDoc.getTestsuite().setPackage(pkg);
+    }
+
+    public void setNoofErrorsInTestSuite(int errors) {
+        testsuiteDoc.getTestsuite().setErrors(errors);
+    }
+
+    public void setNoofFailuresInTestSuite(int failures) {
+        testsuiteDoc.getTestsuite().setFailures(failures);
+    }
+
+    public void systemOut(String systemout) {
+        systemOut.append(systemout);
+    }
+
+    public void systemErr(String systemerr) {
+        systemErr.append(systemerr);
+    }
+
+    public void setSystemOut(String systemout) {
+        testsuiteDoc.getTestsuite().setSystemOut(systemout);
+    }
+
+    public void setSystemErr(String systemerr) {
+        testsuiteDoc.getTestsuite().setSystemErr(systemerr);
+    }
+
+    public Testcase addTestCase(String name, double time, HashMap<String, String> testProperties) {
+        Testcase testcase = testsuiteDoc.getTestsuite().addNewTestcase();
+        testcase.setName(name);
+        testcase.setTime(String.valueOf(time / 1000));
+        noofTestCases++;
+        totalTime += time;
+
+        setTestProperties(testProperties, testcase);
+
+        return testcase;
+    }
+
+    private void setTestProperties(HashMap<String, String> testProperties, Testcase testcase) {
+        if(!this.includeTestProperties)
+            return;
+
+        Properties properties = testcase.addNewProperties();
+        setProperties(properties, testProperties);
+    }
+
+    public Testcase addTestCaseWithFailure(String name, double time, String failure, String stacktrace, HashMap<String, String> testProperties) {
+        Testcase testcase = testsuiteDoc.getTestsuite().addNewTestcase();
+        testcase.setName(name);
+        testcase.setTime(String.valueOf(time / 1000));
+        FailureDocument.Failure fail = testcase.addNewFailure();
+        fail.setType(failure);
+        fail.setMessage(failure);
+        fail.setStringValue(stacktrace);
+        noofTestCases++;
+        noofFailures++;
+        totalTime += time;
+
+        setTestProperties(testProperties, testcase);
+
+        return testcase;
+    }
+
+    public Testcase addTestCaseWithError(String name, double time, String error, String stacktrace, HashMap<String, String> testProperties) {
+        Testcase testcase = testsuiteDoc.getTestsuite().addNewTestcase();
+        testcase.setName(name);
+        testcase.setTime(String.valueOf(time / 1000));
+        ErrorDocument.Error err = testcase.addNewError();
+        err.setType(error);
+        err.setMessage(error);
+        err.setStringValue(stacktrace);
+        noofTestCases++;
+        noofErrors++;
+        totalTime += time;
+
+        setTestProperties(testProperties, testcase);
+
+        return testcase;
+    }
+
+    private void setSystemProperties(Properties properties) {
+        Set<?> keys = System.getProperties().keySet();
+        for (Object keyO : keys) {
+            String key = keyO.toString();
+            String value = System.getProperty(key);
+            Property prop = properties.addNewProperty();
+            prop.setName(key);
+            prop.setValue(value);
+        }
+    }
+
+    private void setProperties(Properties properties, HashMap<String, String> propertiesToSet) {
+        for (Map.Entry<String, String> stringStringEntry : propertiesToSet.entrySet()) {
+            Property prop = properties.addNewProperty();
+            prop.setName(stringStringEntry.getKey());
+            prop.setValue(stringStringEntry.getValue());
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void save(File file) throws IOException {
+        finishReport();
+
+        @SuppressWarnings("rawtypes")
+        Map prefixes = new HashMap();
+        prefixes.put("", "http://smartbear.com/readyapi/junit");
+
+        testsuiteDoc.save(file, new XmlOptions().setSaveOuter().setCharacterEncoding("utf-8").setUseDefaultNamespace()
+                .setSaveImplicitNamespaces(prefixes));
+    }
+
+    public TestsuiteDocument finishReport() {
+        testsuiteDoc.getTestsuite().setTests(noofTestCases);
+        testsuiteDoc.getTestsuite().setFailures(noofFailures);
+        testsuiteDoc.getTestsuite().setErrors(noofErrors);
+        testsuiteDoc.getTestsuite().setTime(String.valueOf(totalTime / 1000));
+
+        return testsuiteDoc;
+    }
+}

--- a/modules/maven-plugin/src/main/java/com/smartbear/readyapi4j/maven/RunMojo.java
+++ b/modules/maven-plugin/src/main/java/com/smartbear/readyapi4j/maven/RunMojo.java
@@ -89,13 +89,13 @@ public class RunMojo
     @Parameter(defaultValue = "true")
     private boolean failOnFailures;
 
-    @Parameter(required = true, property = "ready-api-test-server.username")
+    @Parameter(required = true, property = "testserver.username")
     private String username;
 
-    @Parameter(required = true, property = "ready-api-test-server.password")
+    @Parameter(required = true, property = "testserver.password")
     private String password;
 
-    @Parameter(required = true, property = "ready-api-test-server.endpoint")
+    @Parameter(required = true, property = "testserver.endpoint")
     private String server;
 
     @Parameter(defaultValue = "${project.basedir}/src/test/resources/recipes", required = true)

--- a/modules/maven-plugin/src/main/java/com/smartbear/readyapi4j/maven/RunMojo.java
+++ b/modules/maven-plugin/src/main/java/com/smartbear/readyapi4j/maven/RunMojo.java
@@ -1,0 +1,343 @@
+package com.smartbear.readyapi4j.maven;
+
+/*
+ * Copyright 2004-2015 SmartBear Software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.google.common.collect.Lists;
+import com.smartbear.readyapi.client.model.ProjectResultReport;
+import com.smartbear.readyapi.client.model.TestCaseResultReport;
+import com.smartbear.readyapi.client.model.TestStepResultReport;
+import com.smartbear.readyapi.client.model.TestSuiteResultReport;
+import com.smartbear.readyapi4j.TestRecipe;
+import com.smartbear.readyapi4j.TestRecipeBuilder;
+import com.smartbear.readyapi4j.execution.Execution;
+import com.smartbear.readyapi4j.execution.RecipeExecutor;
+import com.smartbear.readyapi4j.facade.execution.RecipeExecutorBuilder;
+import com.smartbear.readyapi4j.testserver.execution.ProjectExecutionRequest;
+import com.smartbear.readyapi4j.testserver.execution.ProjectExecutor;
+import com.smartbear.readyapi4j.testserver.execution.TestServerClient;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Resource;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.shared.filtering.MavenFilteringException;
+import org.apache.maven.shared.filtering.MavenResourcesExecution;
+import org.apache.maven.shared.filtering.MavenResourcesFiltering;
+import org.apache.maven.shared.model.fileset.FileSet;
+import org.apache.maven.shared.model.fileset.util.FileSetManager;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import static com.smartbear.readyapi4j.testserver.execution.ProjectExecutionRequest.Builder.forProjectFile;
+
+@Mojo(name = "run")
+public class RunMojo
+        extends AbstractMojo {
+    @Component
+    private MavenResourcesFiltering resourcesFiltering;
+
+    @Component
+    private MavenProject mavenProject;
+
+    @Component
+    private MavenSession mavenSession;
+
+    @Parameter
+    private Map properties;
+
+    @Parameter
+    private String environment;
+
+    @Parameter(defaultValue = "false")
+    private boolean async;
+
+    @Parameter
+    private String callback;
+
+    @Parameter
+    private boolean disableFiltering;
+
+    @Parameter(defaultValue = "true")
+    private boolean failOnFailures;
+
+    @Parameter(required = true, property = "ready-api-test-server.username")
+    private String username;
+
+    @Parameter(required = true, property = "ready-api-test-server.password")
+    private String password;
+
+    @Parameter(required = true, property = "ready-api-test-server.endpoint")
+    private String server;
+
+    @Parameter(defaultValue = "${project.basedir}/src/test/resources/recipes", required = true)
+    private File recipeDirectory;
+
+    @Parameter(defaultValue = "${project.basedir}/target/test-recipes", required = true)
+    private File targetDirectory;
+
+    @Parameter(defaultValue = "${basedir}/target/surefire-reports")
+    private File reportTarget;
+
+    private RecipeExecutor recipeExecutor;
+
+    public void execute()
+            throws MojoExecutionException, MojoFailureException {
+        try {
+            if (mavenSession.getSystemProperties().getProperty("skipApiTests") != null) {
+                return;
+            }
+
+            List<String> files = getIncludedFiles();
+
+            if (files.isEmpty()) {
+                getLog().warn("Missing matching files in project");
+                return;
+            }
+
+            readRecipeProperties();
+            initRecipeExecutor();
+
+            JUnitReport report = async ? null : new JUnitReport();
+
+            int recipeCount = 0;
+            int projectCount = 0;
+            int failCount = 0;
+
+            ProjectResultReport response;
+            for (String file : files) {
+                String fileName = file.toLowerCase();
+
+                File f = new File(recipeDirectory, file);
+
+                if (fileName.endsWith(".json")) {
+                    recipeCount++;
+                    response = runJsonRecipe(f);
+                } else if (fileName.endsWith(".xml")) {
+                    projectCount++;
+                    response = runXmlProject(f);
+                } else {
+                    getLog().warn("Unexpected filename: " + fileName);
+                    continue;
+                }
+
+                try {
+                    handleResponse(response, report, file);
+                } catch (MojoFailureException exception) {
+                    failCount++;
+                }
+            }
+
+            getLog().info("Ready! API TestServer Maven Plugin");
+            getLog().info("--------------------------------------");
+            getLog().info("Recipes run: " + recipeCount);
+            getLog().info("Projects run: " + projectCount);
+            getLog().info("Failures: " + failCount);
+
+            if (report != null) {
+                report.setTestSuiteName(mavenProject.getName());
+                report.setNoofFailuresInTestSuite(failCount);
+
+                if (!reportTarget.exists()) {
+                    if (!reportTarget.mkdirs()) {
+                        throw new MojoExecutionException("Failed to create report directory: " + reportTarget);
+                    }
+                }
+
+                report.save(new File(reportTarget, "recipe-report.xml"));
+
+                if (failCount > 0 && failOnFailures) {
+                    throw new MojoFailureException(failCount + " failures during test execution");
+                }
+            }
+
+        } catch (MojoFailureException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new MojoExecutionException("Error running recipe", e);
+        }
+    }
+
+    private void initRecipeExecutor() {
+        RecipeExecutorBuilder recipeExecutorBuilder = new RecipeExecutorBuilder();
+        if (StringUtils.isNotEmpty(server)) {
+            recipeExecutorBuilder.withEndpoint(server);
+            recipeExecutorBuilder.withUser(username);
+            recipeExecutorBuilder.withPassword(password);
+        }
+        recipeExecutor = recipeExecutorBuilder.build();
+    }
+
+    private void readRecipeProperties() throws IOException {
+        File recipeProperties = new File(recipeDirectory, "recipe.properties");
+        if (properties == null) {
+            properties = new HashMap();
+        }
+        if (recipeProperties.exists()) {
+            Properties props = new Properties();
+            props.load(new FileInputStream(recipeProperties));
+            getLog().debug("Read " + props.size() + " properties from recipe.properties");
+
+            // override with properties in config section
+            if (properties != null) {
+                props.putAll(properties);
+            }
+
+            properties = props;
+        }
+    }
+
+    private List<String> getIncludedFiles() {
+
+        FileSetManager fileSetManager = new FileSetManager();
+
+        FileSet fileSet = new FileSet();
+        fileSet.setDirectory(recipeDirectory.getAbsolutePath());
+        fileSet.addInclude("**/*.json");
+        fileSet.addInclude("**/*.xml");
+
+        return Arrays.asList(fileSetManager.getIncludedFiles(fileSet));
+    }
+
+    private void handleResponse(ProjectResultReport result, JUnitReport report, String recipeFileName) throws IOException, MojoFailureException {
+        getLog().debug("Response body:" + result.toString());
+
+        if (report != null) {
+            if (result.getStatus() == ProjectResultReport.StatusEnum.FAILED) {
+
+                String message = logErrorsToConsole(result);
+                report.addTestCaseWithFailure(recipeFileName, result.getTimeTaken(),
+                        message, "<missing stacktrace>", new HashMap<String, String>(properties));
+
+                throw new MojoFailureException("Recipe failed, recipe file: " + recipeFileName);
+            } else {
+                report.addTestCase(recipeFileName, result.getTimeTaken(), new HashMap<String, String>(properties));
+            }
+        }
+    }
+
+    private String logErrorsToConsole(ProjectResultReport result) {
+
+        List<String> messages = new ArrayList<>();
+
+        for (TestSuiteResultReport testSuiteResultReport : result.getTestSuiteResultReports()) {
+            for (TestCaseResultReport testCaseResultReport : testSuiteResultReport.getTestCaseResultReports()) {
+                for (TestStepResultReport stepResultReport : testCaseResultReport.getTestStepResultReports()) {
+                    if (stepResultReport.getAssertionStatus() == TestStepResultReport.AssertionStatusEnum.FAILED) {
+                        getLog().error("Failed " + testSuiteResultReport.getTestSuiteName() + " / " +
+                                testCaseResultReport.getTestCaseName() + " / " + stepResultReport.getTestStepName());
+                        for (String message : stepResultReport.getMessages()) {
+                            messages.add(message);
+                            getLog().error("- " + message);
+                        }
+                    }
+                }
+            }
+        }
+
+        return Arrays.toString(messages.toArray());
+    }
+
+    private ProjectResultReport runXmlProject(File file) throws IOException, MavenFilteringException, MojoFailureException {
+        if (StringUtils.isEmpty(server)) {
+            throw new MojoFailureException("Project execution is supported only with TestServer, not locally.");
+        }
+        getLog().info("Executing project " + file.getName());
+
+        ProjectExecutionRequest executionRequest = forProjectFile(file)
+                .forEnvironment(environment)
+                .build();
+        TestServerClient testServerClient = TestServerClient.fromUrl(server);
+        testServerClient.setCredentials(username, password);
+        ProjectExecutor projectExecutor = testServerClient.createProjectExecutor();
+        Execution execution = async ? projectExecutor.submitProject(executionRequest) :
+                projectExecutor.executeProject(executionRequest);
+        return execution.getCurrentReport();
+    }
+
+    private ProjectResultReport runJsonRecipe(File file) throws IOException, MavenFilteringException, MojoFailureException {
+
+        if (!disableFiltering) {
+            file = filterRecipe(file);
+        }
+
+        getLog().info("Running recipe " + file.getName());
+        TestRecipe testRecipe;
+        try (FileInputStream fileInputStream = new FileInputStream(file)) {
+            String recipeText = IOUtils.toString(fileInputStream);
+            testRecipe = TestRecipeBuilder.createFrom(recipeText);
+        }
+        if (testRecipe == null) {
+            throw new MojoFailureException(String.format("Couldn't read test recipe from file: %s, please make sure it contains a valid test recipe.", file.getName()));
+        }
+
+        Execution execution = async ? recipeExecutor.submitRecipe(testRecipe) : recipeExecutor.executeRecipe(testRecipe);
+        return execution.getCurrentReport();
+    }
+
+    private File filterRecipe(File file) throws MavenFilteringException, MojoFailureException {
+        if (!targetDirectory.exists()) {
+            if (!targetDirectory.mkdirs()) {
+                throw new MojoFailureException("Couldn't create target directory: " + targetDirectory);
+            }
+        }
+
+        Resource fileResource = new Resource();
+        fileResource.setDirectory(recipeDirectory.getAbsolutePath());
+
+        String filename = file.getAbsolutePath().substring(recipeDirectory.getAbsolutePath().length());
+
+        fileResource.addInclude(filename);
+        fileResource.setFiltering(true);
+
+        MavenResourcesExecution resourcesExecution = new MavenResourcesExecution();
+        resourcesExecution.setOutputDirectory(targetDirectory);
+        resourcesExecution.setResources(Lists.newArrayList(fileResource));
+        resourcesExecution.setOverwrite(true);
+        resourcesExecution.setSupportMultiLineFiltering(true);
+        resourcesExecution.setEncoding(Charset.defaultCharset().toString());
+
+        if (properties != null && !properties.isEmpty()) {
+            Properties props = new Properties();
+            props.putAll(properties);
+            getLog().debug("Adding additional properties: " + properties.toString());
+            resourcesExecution.setAdditionalProperties(props);
+        }
+
+        resourcesExecution.setMavenProject(mavenProject);
+        resourcesExecution.setMavenSession(mavenSession);
+        resourcesExecution.setUseDefaultFilterWrappers(true);
+
+        resourcesFiltering.filterResources(resourcesExecution);
+
+        return new File(targetDirectory, filename);
+    }
+}

--- a/modules/maven-plugin/src/main/resources/report.xsd
+++ b/modules/maven-plugin/src/main/resources/report.xsd
@@ -1,0 +1,86 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://smartbear.com/readyapi/junit"
+           elementFormDefault="qualified"
+           xmlns:tns="http://smartbear.com/readyapi/junit">
+
+    <xs:element name="testsuite" type="tns:testsuite" />
+    <xs:complexType name="testsuite">
+
+        <xs:sequence>
+            <xs:element ref="tns:properties" minOccurs="0" maxOccurs="1" />
+            <xs:element ref="tns:testcase" minOccurs="0"
+                        maxOccurs="unbounded" />
+            <xs:element name="system-out" type="xs:normalizedString"
+                        minOccurs="1" maxOccurs="1" />
+            <xs:element name="system-err" type="xs:normalizedString"
+                        minOccurs="1" maxOccurs="1" />
+        </xs:sequence>
+
+        <xs:attribute name="errors" type="xs:int" />
+        <xs:attribute name="failures" type="xs:int" />
+        <xs:attribute name="name" type="xs:string" />
+        <xs:attribute name="tests" type="xs:int" />
+        <xs:attribute name="time" type="xs:string" />
+        <xs:attribute name="package" type="xs:string"></xs:attribute>
+        <xs:attribute name="id" type="xs:string"></xs:attribute>
+    </xs:complexType>
+
+    <xs:element name="properties" type="tns:properties" />
+    <xs:complexType name="properties">
+        <xs:sequence>
+            <xs:element ref="tns:property" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:element name="property" type="tns:property" />
+    <xs:complexType name="property">
+        <xs:attribute name="name" type="xs:string"></xs:attribute>
+        <xs:attribute name="value" type="xs:string"></xs:attribute>
+    </xs:complexType>
+
+    <xs:element name="testcase" type="tns:testcase" />
+    <xs:complexType name="testcase">
+        <xs:sequence>
+            <xs:element ref="tns:properties" minOccurs="0" maxOccurs="1" />
+            <xs:element ref="tns:failure" minOccurs="0" maxOccurs="1"/>
+            <xs:element ref="tns:error" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string"></xs:attribute>
+        <xs:attribute name="time" type="xs:string"></xs:attribute>
+        <xs:attribute name="package" type="xs:string"></xs:attribute>
+    </xs:complexType>
+
+    <xs:element name="failure">
+        <xs:complexType>
+            <xs:simpleContent>
+                <xs:extension base="xs:string">
+                    <xs:attribute name="type" type="xs:string" />
+                    <xs:attribute name="message" type="xs:string"></xs:attribute>
+                </xs:extension>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="error">
+        <xs:complexType>
+            <xs:simpleContent>
+                <xs:extension base="xs:string">
+                    <xs:attribute name="type" type="xs:string" />
+                    <xs:attribute name="message" type="xs:string"></xs:attribute>
+                </xs:extension>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+
+
+
+    <xs:element name="testsuites" type="tns:testsuites"></xs:element>
+
+    <xs:complexType name="testsuites">
+        <xs:sequence>
+            <xs:element name="testsuite" type="tns:testsuite"></xs:element>
+        </xs:sequence>
+    </xs:complexType>
+</xs:schema>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,9 @@
         <module>modules/facade</module>
         <module>modules/groovy-dsl</module>
         <module>modules/swagger</module>
+        <module>modules/maven-plugin</module>
         <module>modules/samples</module>
+        <module>modules/maven-plugin-tester</module>
     </modules>
     <packaging>pom</packaging>
     <name>ReadyAPI4j</name>


### PR DESCRIPTION
I will extend it for local execution. So far I have moved the plugin from a separate repo to readyapi4j and updated it to use latest version of readyapi4j libraries.

I have added a maven-plugin-tester module as well to test the maven plugin as part of the build.